### PR TITLE
fix: the network packet reassembly function copies p... in...

### DIFF
--- a/src/component/net_channel_ex.c
+++ b/src/component/net_channel_ex.c
@@ -61,6 +61,9 @@ static unsigned char* merge_packet(List_t* list, unsigned int* mergelen) {
 	for (cur = list->head; cur; cur = next) {
 		packet = pod_container_of(cur, NetReactorPacket_t, _.node);
 		next = cur->next;
+		if (off + packet->_.bodylen < off) {
+			return NULL;
+		}
 		off += packet->_.bodylen;
 	}
 	ptr = (unsigned char*)malloc(off);


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `src/component/net_channel_ex.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-004 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-004` |
| **File** | `src/component/net_channel_ex.c:73` |

**Description**: The network packet reassembly function copies packet body data into a destination buffer using the attacker-controlled bodylen field from the packet header as the copy length, with no validation that bodylen fits within the destination buffer. A single malformed network packet with an oversized bodylen value will overflow the heap buffer, corrupting adjacent memory.

## Changes
- `src/component/net_channel_ex.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
